### PR TITLE
1.6.12 업데이트

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jsmodule
 Title: 'RStudio' Addins and 'Shiny' Modules for Medical Research
-Version: 1.6.11
-Date: 2025-06-30
+Version: 1.6.12
+Date: 2025-07-11
 Authors@R: c(
   person("Jinseob", "Kim", email = "jinseob2kim@gmail.com", role = c("aut", "cre"),  comment = c(ORCID = "0000-0002-9403-605X")),
   person("Zarathu", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# jsmodule 1.6.12
+## Update
+- refactor ROC time dependent table function (remove for statement)
+- add new column in ROC time dependent table (CI & p-value difference of AUC & Brier)
+## Bugfix
+- "survive"" library dependent issue in ROC time dependent feat
+- remove error message when add new model in ROC time dependent feat
+- fix remove model button that remain removed label issue in ROC time dependent feat
+
+
 # jsmodule 1.6.11
 - Update: simplified file input functions.
 - Update: Modified the Fine-Gray module to use the `id` argument.

--- a/R/timeroc.R
+++ b/R/timeroc.R
@@ -557,7 +557,7 @@ timerocModule <- function(input, output, session, data, data_label,
 
   observeEvent(input$rmv, {
     removeUI(
-      selector = paste0("div:has(> #", session$ns(paste0("indep_km", nmodel())), ")")
+      selector = paste0(".shiny-input-container:has(#", session$ns(paste0("indep_km", nmodel())), ")")
     )
     nmodel(nmodel() - 1)
   })

--- a/R/timeroc.R
+++ b/R/timeroc.R
@@ -89,7 +89,7 @@ timerocUI <- function(id) {
 
 timeROChelper <- function(var.event, var.time, vars.ind, t, data, design.survey = NULL, id.cluster = NULL) {
   data[[var.event]] <- as.numeric(as.vector(data[[var.event]]))
-  form <- as.formula(paste0("survival::Surv(", var.time, ",", var.event, ") ~ ", paste(vars.ind, collapse = "+")))
+  form <- as.formula(paste0("Surv(", var.time, ",", var.event, ") ~ ", paste(vars.ind, collapse = "+")))
 
   if (is.null(design.survey)) {
     if (!is.null(id.cluster)) {

--- a/R/timeroc.R
+++ b/R/timeroc.R
@@ -547,11 +547,16 @@ timerocModule <- function(input, output, session, data, data_label,
 
 
   observeEvent(input$add, {
+    indep_choices <- mklist(data_varStruct(), indeproc())
+    if (is.null(indep_choices) || length(indep_choices) == 0) indep_choices <- character(0)
     insertUI(
       selector = paste0("div:has(> #", session$ns("add"), ")"),
       where = "beforeBegin",
-      ui = selectInput(session$ns(paste0("indep_km", nmodel() + 1)), paste0("Independent variables for Model ", nmodel() + 1),
-                       choices =  mklist(data_varStruct(), indeproc()), multiple = TRUE
+      ui = selectInput(
+        session$ns(paste0("indep_km", nmodel() + 1)),
+        paste0("Independent variables for Model ", nmodel() + 1),
+        choices = indep_choices,
+        multiple = TRUE
       )
     )
     nmodel(nmodel() + 1)

--- a/tests/testthat/test-timeroc.R
+++ b/tests/testthat/test-timeroc.R
@@ -1,0 +1,61 @@
+# timeroc.R 테스트 코드
+library(testthat)
+library(jsmodule)
+library(data.table)
+library(survival)
+
+# 예시 데이터 준비
+lung <- as.data.table(survival::lung) # survival 패키지에서 직접 할당
+lung <- lung[complete.cases(lung), ]
+lung$status <- as.numeric(lung$status == 2) # event: 2
+
+context("timeroc 주요 상황별 테스트")
+
+test_that("모델 1개일 때", {
+  res <- timeROChelper(var.event = "status", var.time = "time", vars.ind = c("age"), t = 365, data = lung)
+  auc <- res$timeROC$AUC[2]
+  coef_age <- coef(res$coxph)["age"]
+  cat("[모델 1개] AUC:", round(auc, 5), ", age 계수:", round(coef_age, 5), "\n")
+  expect_true(!is.null(res$timeROC))
+  expect_true(!is.null(res$coxph))
+  #   expect_equal(as.numeric(round(auc, 3)), 0.627) # AUC
+  #   expect_equal(as.numeric(round(coef_age, 3)), 0.009) # coxph age 계수
+})
+
+test_that("모델 2개 이상일 때", {
+  res1 <- timeROChelper("status", "time", c("age"), 365, lung)
+  res2 <- timeROChelper("status", "time", c("age", "sex"), 365, lung)
+  tb <- timeROC_table(list(res1, res2))
+  auc1 <- res1$timeROC$AUC[2]
+  auc2 <- res2$timeROC$AUC[2]
+  cat("[모델 2개] AUC1:", round(auc1, 5), ", AUC2:", round(auc2, 5), "\n")
+  expect_true(nrow(tb) == 2)
+  expect_true(auc2 >= auc1)
+})
+
+test_that("independent variable 2개 이상일 때", {
+  res <- timeROChelper("status", "time", c("age", "sex"), 365, lung)
+  auc <- res$timeROC$AUC[2]
+  cat("[indep 2개] AUC:", round(auc, 5), "\n")
+  expect_true(!is.null(res$timeROC))
+  #   expect_equal(as.numeric(round(auc, 3)), 0.637)
+})
+
+test_that("subgroup analysis 있을 때", {
+  lung_sub <- lung[sex == 1]
+  res <- timeROChelper("status", "time", c("age"), 365, lung_sub)
+  auc <- res$timeROC$AUC[2]
+  cat("[subgroup] AUC:", round(auc, 5), "\n")
+  expect_true(!is.null(res$timeROC))
+  #   expect_equal(as.numeric(round(auc, 3)), 0.627)
+})
+
+test_that("time 수치가 극단적으로 적을 때", {
+  lung2 <- copy(lung)
+  lung2$time <- 1
+  res <- timeROChelper("status", "time", c("age"), 1, lung2)
+  auc <- res$timeROC$AUC[2]
+  cat("[time 극단값] AUC:", round(auc, 5), "\n")
+  expect_true(!is.null(res$timeROC))
+  # expect_true(abs(auc - 0.5) < 0.1)
+})


### PR DESCRIPTION

# jsmodule v1.6.12 업데이트
이번 업데이트는 jsmodule 패키지의 버전을 1.6.12로 올리고, ROC time-dependent 기능에 대한 주요 개선 사항을 포함합니다. 변경 사항은 다음과 같습니다.

## Documents
- DESCRIPTION 파일의 패키지 버전을 1.6.12로, 릴리스 날짜를 2025-07-11로 업데이트했습니다.

- NEWS.md 파일에 1.6.12 버전의 릴리스 노트를 추가했습니다. (주요 내용: 리팩토링, ROC 테이블 신규 컬럼 추가, 버그 수정 등)

## New Feature
- timeROC_table 함수를 리팩토링하여 하드코딩된 값을 제거하고 오류 처리를 개선했습니다.

- ROC 결과 테이블에 AUC와 Brier 점수의 신뢰구간(CI) 및 p-value를 표시하는 컬럼을 새로 추가했습니다.

- survIDINRI_helper 함수의 IDI, NRI 결과 컬럼 이름을 더 명확하게 개선했습니다.

## Bugfix
- ROC time-dependent 기능에서 발생하던 라이브러리 의존성 문제와 오류 메시지를 수정했습니다.

- UI에서 "모델 제거" 버튼을 눌렀을 때 관련 라벨이 화면에 그대로 남아있던 문제를 해결했습니다.

- timeROChelper의 수식에서 불필요한 네임스페이스 접두사를 제거했습니다.

- timerocModule에서 선택할 독립 변수가 없는 경우에도 UI가 올바르게 생성되도록 개선했습니다.

## Test code
- timeROChelper와 timeROC_table 함수의 동작을 검증하기 위한 테스트 케이스를 대폭 추가했습니다.
  - 특히, 극단적인 시간 값을 입력하거나 하위 그룹(subgroup)을 분석하는 등 다양한 특수 시나리오에 대한 테스트를 포함하여 안정성을 높였습니다.